### PR TITLE
Mutable Variables and Invariants

### DIFF
--- a/src/scopes.js
+++ b/src/scopes.js
@@ -33,6 +33,11 @@ class VerificationScope {
     return this.node;
   }
   
+  bodySource() {
+    // -> JSSource
+    throw new Error("not implemented");
+  }
+
   vars() {
     // -> Array<string>
     return findDefs(this.node).concat(this.surroundingVars());
@@ -112,7 +117,7 @@ export class FunctionScope extends VerificationScope {
           theorems = toProve.map(pc => {
             const pc2 = replaceFunctionResult(this.node, pc),
                   desc = this.describe(pc);
-            return new Theorem(params, pre, body, pc2, desc);
+            return new Theorem(this, params, pre, body, pc2, desc);
           });
     return theorems.concat(super.theorems());
   }
@@ -146,7 +151,7 @@ export class TopLevelScope extends VerificationScope {
     const stmts = this.normalizedNode().body.body,
           body = { type: "BlockStatement", body: stmts.slice(0, -1)},
           theorems = this.invariants().map(pc =>
-            new Theorem([], [], body, pc, `initially:\n${stringify(pc)}`));
+            new Theorem(this, [], [], body, pc, `initially:\n${stringify(pc)}`));
     return theorems.concat(super.theorems());
   }
   
@@ -166,4 +171,8 @@ export class TopLevelScope extends VerificationScope {
     return [];
   }
   
+  bodySource() {
+    // -> JSSource
+    return stringify(program(...this.normalizedNode().body.body));
+  }
 }

--- a/src/scopes.js
+++ b/src/scopes.js
@@ -105,7 +105,7 @@ export class FunctionScope extends VerificationScope {
 
   theorems() {
     // -> Array<Theorem>
-    const params = this.node.params.map(p => p.name).concat(["_res"]),
+    const params = this.node.params.map(p => p.name).concat(this.surroundingVars()),
           pre = this.preConditions().concat(this.parent.invariants()),
           body = this.normalizedNode().body,
           toProve = this.postConditions().concat(this.invariants()),

--- a/src/theorems.js
+++ b/src/theorems.js
@@ -34,11 +34,11 @@ export default class Theorem {
 ; parameters
 ${parameters}
 
-; requirements
-${requirements}
-
 ; body
 ${body}
+
+; requirements
+${requirements}
 
 ; post condition
 ${post}

--- a/src/theorems.js
+++ b/src/theorems.js
@@ -7,8 +7,9 @@ import { statementToSMT, smtToValue, createVars, varsToSMT } from "./javascript.
 import { preamble } from "./defs-smt.js";
 
 export default class Theorem {
-  constructor(vars, pre, body, post, description) {
-    // Array<string>, Array<Expression>, Statement, Expression, string -> Theorem
+  constructor(scope, vars, pre, body, post, description) {
+    // VerificationScope, Array<string>, Array<Expression>, Statement, Expression, string -> Theorem
+    this.scope = scope;
     this.vars = vars;
     this.pre = pre;
     this.body = body;

--- a/src/visitors.js
+++ b/src/visitors.js
@@ -43,6 +43,7 @@ class FindScopes extends Visitor {
     state.unshift(newScope);
     super.visitFunctionDeclaration(node, state, path);
     state.shift();
+    return node;
   }
 }
 

--- a/src/visitors.js
+++ b/src/visitors.js
@@ -1,22 +1,20 @@
 import { obj } from "lively.lang";
+import { declarationsOfScope } from "lively.ast/lib/query.js";
 import Visitor from "lively.ast/generated/estree-visitor.js";
 
 import { TopLevelScope, ClassScope, FunctionScope } from "./scopes.js";
 
 class RemoveAssertions extends Visitor {
-  accept(node, state, path) {
+  visitExpressionStatement(node, state, path) {
     // Node, null, Array<Node> -> Node
-    const n = super.accept(node, state, path);
-    if (n.type == "ExpressionStatement" &&
-        n.expression.type == "CallExpression" &&
-        n.expression.callee.type == "Identifier" &&
-        (n.expression.callee.name == "requires" ||
-         n.expression.callee.name == "ensures" ||
-         n.expression.callee.name == "assert" ||
-         n.expression.callee.name == "invariant") ) {
+    const expr = node.expression;
+    if (expr.type == "CallExpression" &&
+        expr.callee.type == "Identifier" &&
+        ["requires", "ensures", "assert", "invariant"]
+          .includes(expr.callee.name)) {
       return {type: "EmptyStatement"};
     }
-    return n;
+    return super.visitExpressionStatement(node, state, path);
   }
 }
 
@@ -27,24 +25,24 @@ export function removeAssertions(node) {
 }
 
 class FindScopes extends Visitor {
-  accept(node, state, path) {
+  visitClassDeclaration(node, state, path) {
     // Node, Array<VerificationScope>, Array<Node> -> Node
-    switch (node.type) {
-      case "ClassDeclaration":
-      case "MethodDefinition":
-      case "ArrowFunctionExpression":
-      case "FunctionExpression":
-        throw new Error("not supported");
-      case "FunctionDeclaration":
-        const newScope = new FunctionScope(state[0], node);
-        state.unshift(newScope);
-        super.accept(node, state, path);
-        state.shift();
-        break;
-      default:
-        super.accept(node, state, path);
-    }
-    return node;
+    throw new Error("not supported");
+  }
+  visitArrowFunctionExpression(node, state, path) {
+    // Node, Array<VerificationScope>, Array<Node> -> Node
+    throw new Error("not supported");
+  }
+  visitFunctionExpression(node, state, path) {
+    // Node, Array<VerificationScope>, Array<Node> -> Node
+    throw new Error("not supported");
+  }
+  visitFunctionDeclaration(node, state, path) {
+    // Node, Array<VerificationScope>, Array<Node> -> Node
+    const newScope = new FunctionScope(state[0], node);
+    state.unshift(newScope);
+    super.visitFunctionDeclaration(node, state, path);
+    state.shift();
   }
 }
 
@@ -58,21 +56,20 @@ export function findScopes(node) {
 
 class ReplaceFunctionResult extends Visitor {
   constructor(func) {
+    // FunctionDeclaration -> ReplaceFunctionResult
     this.name = func.id.name;
     this.params = func.params.map(p => p.name);
   }
-  accept(node, state, path) {
+  visitCallExpression(node, state, path) {
     // Node, null, Array<Node> -> Node
-    const n = super.accept(node, state, path);
-    if (n.type == "CallExpression" &&
-      n.callee.type == "Identifier" &&
-      n.callee.name == this.name &&
-      n.arguments.length == this.params.length &&
-      n.arguments.every((arg, idx) =>
-        arg.type == "Identifier" && arg.name == this.params[idx])) {
+    if (node.callee.type == "Identifier" &&
+        node.callee.name == this.name &&
+        node.arguments.length == this.params.length &&
+        node.arguments.every((arg, idx) =>
+          arg.type == "Identifier" && arg.name == this.params[idx])) {
       return {type: "Identifier", name: "_res"};
     }
-    return n;
+    return super.visitCallExpression(node, state, path);
   }
 }
 
@@ -80,4 +77,51 @@ export function replaceFunctionResult(func, node) {
   // Node -> Node
   const ra = new ReplaceFunctionResult(func);
   return ra.accept(obj.deepCopy(node), null, []);
+}
+
+class FindDefs extends Visitor {
+  
+  visitVariableDeclaration(node, scope, path) {
+    scope.varDecls.push(node);
+    return super.visitVariableDeclaration(node, scope, path);
+  }
+
+  visitFunctionDeclaration (node, scope, path) {
+    scope.funcDecls.push(node);
+    return node; // do not enter function
+  }
+
+  visitFunctionExpression (node, scope, path) {
+    return node; // do not enter function
+  }
+
+  visitArrowFunctionExpression(node, scope, path) {
+    return node; // do not enter function
+  }
+  
+  visitCatchClause (node, scope, path) {
+    scope.catches.push(node.param);
+    return super.visitCatchClause(node, scope, path);
+  }
+
+  visitClassDeclaration(node, scope, path) {
+    scope.classDecls.push(node);
+    return node;
+  }
+}
+
+export function findDefs(node) {
+  // Node -> Array<string>
+  const fd = new FindDefs(),
+        scope = {
+          node,
+          params: node.params || [],
+          funcDecls: [],
+          varDecls: [],
+          catches: [],
+          classDecls: [],
+          importDecls: []
+        };
+  fd.accept(node, scope, []);
+  return declarationsOfScope(scope).map(id => id.name);
 }

--- a/tests/verify.js
+++ b/tests/verify.js
@@ -91,7 +91,7 @@ describe("verify", () => {
       
       function decrement() {
         if (counter > 0) counter--;
-        ensures(counter > 0 ? counter < old(counter) : counter === old(counter));
+        ensures(old(counter) > 0 ? counter < old(counter) : counter === old(counter));
       }
     }).toString();
     
@@ -130,7 +130,7 @@ describe("verify", () => {
     });
     
     it("decrement decrements", async () => {
-      expect(theorems[5].description).to.be.eql("decrement:\ncounter > 0 ? counter < old(counter) : counter === old(counter)");
+      expect(theorems[5].description).to.be.eql("decrement:\nold(counter) > 0 ? counter < old(counter) : counter === old(counter)");
       await theorems[5].solve();
       expect(theorems[5].isSatisfiable()).to.be.true;
     });


### PR DESCRIPTION
This PR adds support for invariants and mutable variables.
Invariants are essentially post-conditions for the scope they are in, and pre- and post- conditions for all functions declared below that scope. Mutual variables allow assignments. In assertions, the initial value of a variable can be referenced with `old(x)`.

The following example can now be verified:

``` javascript
let counter = 0;
invariant(typeof counter == "number");
invariant(counter >= 0);

function increment() {
  counter++;
  ensures(counter > old(counter));
}

function decrement() {
  if (counter > 0) counter--;
  ensures(old(counter) > 0 ? counter < old(counter) : counter === old(counter));
}
```
