### PR TITLE
Verification of While Loops

### DIFF
--- a/src/defs-smt.js
+++ b/src/defs-smt.js
@@ -124,7 +124,7 @@ export const preamble =
 ; /
 (define-fun _js-divide ((a JSVal) (b JSVal)) JSVal
   (ite (and (is-jsnum a) (is-jsnum b))
-    (jsnum (/ (numv a) (numv b)))
+    (jsnum (div (numv a) (numv b)))
   jsundefined)) ; non-standard!
 
 ; %

--- a/src/javascript.js
+++ b/src/javascript.js
@@ -1,4 +1,7 @@
+import { parse } from "lively.ast";
 import { arr } from "lively.lang";
+import { assertionToSMT } from "./assertions.js";
+import { assumesStrings } from "./visitors.js";
 
 /*
 
@@ -124,6 +127,15 @@ export function varsToSMT(vars) {
   return smt;
 }
 
+function incByOne(vars, nvars) {
+  // Vars, Vars -> Vars
+  const res = {};
+  for (const v in vars) {
+    res[v] = nvars[v] > vars[v] ? vars[v] + 1 : vars[v];
+  }
+  return res;
+}
+
 function arrayToSMT(elements, vars) {
   // Array<Identifier>, Vars -> SMTInput
   if (elements.length === 0) return "empty";
@@ -162,12 +174,16 @@ function expressionToSMT(expr, vars) {
 // type BreakLabel = string;
 // type BreakCondition = {cond: Antedecents, label: BreakLabel}
 
+function assert(cond, vars, pc) {
+  // VarName, SMTInput, Vars, Array<SMTInput> -> [SMTInput, Array<BreakCondition>, Vars]
+  if (pc.length == 0) return [`(assert ${cond})\n`, vars, []];
+  return [`(assert (=> (and ${pc.join(' ')}) ${cond}))\n`, vars, []];
+}
+
 function assertEq(left, right, vars, pc) {
   // VarName, SMTInput, Vars, Array<SMTInput> -> [SMTInput, Array<BreakCondition>, Vars]
-  const nvars = incVar(left, vars),
-        eq = `(= ${getVar(left, nvars)} ${right})`;
-  if (pc.length == 0) return [`(assert ${eq})\n`, nvars, []];
-  return [`(assert (=> (and ${pc.join(' ')}) ${eq}))\n`, nvars, []];
+  const nvars = incVar(left, vars);
+  return assert(`(= ${getVar(left, nvars)} ${right})`, nvars, pc);
 }
 
 export function statementToSMT(stmt, vars = {}, pc = []) {
@@ -213,6 +229,14 @@ export function statementToSMT(stmt, vars = {}, pc = []) {
         const [ssmt, nvars2, sbc] = assertEq(id.name, "jsundefined", nvars, pc);
         return [smt + ssmt, nvars2, bc.concat(sbc)];
       }, ["", vars, []]);
+    case 'WhileStatement':
+      const [, lvars] = statementToSMT(stmt.body, vars, pc); // ignore loop body
+      const wvars = incByOne(vars, lvars); // but increment changed vars
+      let wsmt = `(and (not (_truthy ${getVar(stmt.test.name, wvars)}))`;
+      assumesStrings(stmt.body).forEach(str => {
+        wsmt += ` (_truthy ${assertionToSMT(parse(str).body[0].expression, wvars)})`;
+      });
+      return assert(wsmt + ')', wvars, pc);
     case 'ExpressionStatement':
       const {left, right} = stmt.expression;
       if (left.type == 'MemberExpression') {

--- a/src/theorems.js
+++ b/src/theorems.js
@@ -70,6 +70,13 @@ ${post}
     throw new Error("z3 failed to solve problem");
   }
   
+  hasResult() {
+    // -> Bool?
+    const res = this.result();
+    if (!res) return false;
+    return res.startsWith("unsat") || res.startsWith("sat");
+  }
+  
   getModel() {
     // -> { [string]: any }?
     if (this._model) return this._model;

--- a/src/theorems.js
+++ b/src/theorems.js
@@ -44,7 +44,7 @@ ${requirements}
 ${post}
 
 (check-sat)
-(get-value (${this.vars.map(v => `${v}_0`).join(' ')} _res_0))`;
+(get-value (${Object.keys(nvars).map(v => `${v}_0`).join(' ')}))`;
   }
   
   result() {

--- a/src/visitors.js
+++ b/src/visitors.js
@@ -1,4 +1,5 @@
 import { obj } from "lively.lang";
+import { id, funcCall } from "lively.ast/lib/nodes.js";
 import { declarationsOfScope } from "lively.ast/lib/query.js";
 import Visitor from "lively.ast/generated/estree-visitor.js";
 
@@ -57,6 +58,27 @@ class ReplaceFunctionResult extends Visitor {
 export function replaceFunctionResult(func, node) {
   // Node -> Node
   const ra = new ReplaceFunctionResult(func);
+  return ra.accept(obj.deepCopy(node), null, []);
+}
+
+class ReplaceResultFunction extends Visitor {
+  constructor(func) {
+    // FunctionDeclaration -> ReplaceResultFunction
+    this.id = func.id;
+    this.params = func.params;
+  }
+  visitIdentifier(node, state, path) {
+    // Node, null, Array<Node> -> Node
+    if (node.name == "_res") {
+      return funcCall(this.id, ...this.params);
+    }
+    return super.visitIdentifier(node, state, path);
+  }
+}
+
+export function replaceResultFunction(func, node) {
+  // Node -> Node
+  const ra = new ReplaceResultFunction(func);
   return ra.accept(obj.deepCopy(node), null, []);
 }
 

--- a/src/visitors.js
+++ b/src/visitors.js
@@ -1,9 +1,10 @@
 import { obj } from "lively.lang";
-import { id, funcCall } from "lively.ast/lib/nodes.js";
+import { stringify } from "lively.ast";
+import { id, funcCall, block, literal, exprStmt } from "lively.ast/lib/nodes.js";
 import { declarationsOfScope } from "lively.ast/lib/query.js";
 import Visitor from "lively.ast/generated/estree-visitor.js";
 
-import { TopLevelScope, ClassScope, FunctionScope } from "./scopes.js";
+import { TopLevelScope, LoopScope, ClassScope, FunctionScope } from "./scopes.js";
 
 class FindScopes extends Visitor {
   visitClassDeclaration(node, state, path) {
@@ -23,6 +24,14 @@ class FindScopes extends Visitor {
     const newScope = new FunctionScope(state[0], node);
     state.unshift(newScope);
     super.visitFunctionDeclaration(node, state, path);
+    state.shift();
+    return node;
+  }
+  visitWhileStatement(node, state, path) {
+    // Node, Array<VerificationScope>, Array<Node> -> Node
+    const newScope = new LoopScope(state[0], node);
+    state.unshift(newScope);
+    super.visitWhileStatement(node, state, path);
     state.shift();
     return node;
   }
@@ -130,4 +139,81 @@ export function findDefs(node) {
         };
   fd.accept(node, scope, []);
   return declarationsOfScope(scope).map(id => id.name);
+}
+
+class AssumesStrings extends Visitor {
+  
+  visitExpressionStatement(node, strings, path) {
+    // ExpressionStatement, Array<String>, Array<Node> -> Node
+    if (node.expression.type == "AssignmentExpression" &&
+        node.expression.right.type == "Literal" &&
+        typeof(node.expression.right.value) == "string" &&
+        node.expression.right.value.startsWith("@assume:")) {
+      strings.push(node.expression.right.value.substr(8));
+    }
+    return super.visitExpressionStatement(node, strings, path);
+  }
+
+  visitFunctionDeclaration(node, scope, path) {
+    return node; // do not enter function
+  }
+
+  visitFunctionExpression(node, scope, path) {
+    return node; // do not enter function
+  }
+
+  visitArrowFunctionExpression(node, scope, path) {
+    return node; // do not enter function
+  }
+  
+  visitWhileStatement(node, scope, path) {
+    return node; // do not enter loop
+  }
+
+  visitClassDeclaration(node, scope, path) {
+    return node; // do not enter class
+  }
+}
+
+export function assumesStrings(node) {
+  // Node -> Array<string>
+  const fd = new AssumesStrings(),
+        strings = [];
+  fd.accept(node, strings, []);
+  return strings;
+}
+
+export function isAssertion(stmt) {
+  // Statement -> boolean
+  return stmt.type == "ExpressionStatement" &&
+         stmt.expression.type == "CallExpression" &&
+         stmt.expression.callee.type == "Identifier" &&
+         (["requires", "ensures", "assert", "invariant"]
+           .includes(stmt.expression.callee.name)) &&
+         stmt.expression.arguments.length === 1;
+}
+
+class PruneLoops extends Visitor {
+  visitExpressionStatement(node, state, path) {
+    if (isAssertion(node)) {
+      if (node.expression.callee.name == "invariant") {
+        return exprStmt(literal(`@assume:${stringify(node.expression.arguments[0])}`));
+      }
+      return {type: "EmptyStatement"};
+    }
+    return super.visitExpressionStatement(node, state, path);
+  }
+  visitWhileStatement(node, state, path) {
+    return super.visitWhileStatement({
+      type: "WhileStatement",
+      test: node.test,
+      body: block(exprStmt(literal(`@assume:!(${stringify(node.test)})`)), ...node.body.body)
+    }, state, path);
+  }
+}
+
+export function pruneLoops(stmts) {
+  // Array<Statement> -> Array<Statement>
+  const pl = new PruneLoops();
+  return stmts.map(stmt => pl.accept(obj.deepCopy(stmt), null, []));
 }

--- a/src/visitors.js
+++ b/src/visitors.js
@@ -4,26 +4,6 @@ import Visitor from "lively.ast/generated/estree-visitor.js";
 
 import { TopLevelScope, ClassScope, FunctionScope } from "./scopes.js";
 
-class RemoveAssertions extends Visitor {
-  visitExpressionStatement(node, state, path) {
-    // Node, null, Array<Node> -> Node
-    const expr = node.expression;
-    if (expr.type == "CallExpression" &&
-        expr.callee.type == "Identifier" &&
-        ["requires", "ensures", "assert", "invariant"]
-          .includes(expr.callee.name)) {
-      return {type: "EmptyStatement"};
-    }
-    return super.visitExpressionStatement(node, state, path);
-  }
-}
-
-export function removeAssertions(node) {
-  // Node -> Node
-  const ra = new RemoveAssertions();
-  return ra.accept(obj.deepCopy(node), null, []);
-}
-
 class FindScopes extends Visitor {
   visitClassDeclaration(node, state, path) {
     // Node, Array<VerificationScope>, Array<Node> -> Node
@@ -89,6 +69,9 @@ class FindDefs extends Visitor {
 
   visitFunctionDeclaration (node, scope, path) {
     scope.funcDecls.push(node);
+    if (node === scope.node) { // find defs in this function
+      return super.visitFunctionDeclaration(node, scope, path);
+    }
     return node; // do not enter function
   }
 

--- a/tests/verify.js
+++ b/tests/verify.js
@@ -145,4 +145,47 @@ describe("verify", () => {
     });
     
   });
+  
+  describe("loop", () => {
+    
+    const code = (() => {
+      let i = 0;
+
+      while (i < 5) {
+        invariant(i <= 5);
+        i++;
+      }
+      
+      assert(i === 5);
+    }).toString();
+    
+    let theorems;
+    
+    beforeEach(() => {
+      theorems = theoremsInSource(code.substring(14, code.length - 2));
+    });
+
+    it("finds all theorem", () => {
+      expect(theorems).to.have.length(3);
+    });
+    
+    it("invariant holds on entry", async () => {
+      expect(theorems[0].description).to.be.eql("loop entry:\ni <= 5");
+      await theorems[0].solve();
+      expect(theorems[0].isSatisfiable()).to.be.true;
+    });
+    
+    it("invariant maintained by loop", async () => {
+      expect(theorems[1].description).to.be.eql("loop invariant:\ni <= 5");
+      await theorems[1].solve();
+      expect(theorems[1].isSatisfiable()).to.be.true;
+    });
+    
+    it("results in final state", async () => {
+      expect(theorems[2].description).to.be.eql("initially:\ni === 5");
+      await theorems[2].solve();
+      expect(theorems[2].isSatisfiable()).to.be.true;
+    });
+
+  });
 });

--- a/tests/verify.js
+++ b/tests/verify.js
@@ -202,20 +202,20 @@ describe("verify", () => {
       expect(theorems).to.have.length(3);
     });
     
-    it("invariant holds on entry", async () => {
-      expect(theorems[0].description).to.be.eql("loop entry:\ni <= 5");
+    it("results in final state", async () => {
+      expect(theorems[0].description).to.be.eql("assert:\ni === 5");
       await theorems[0].solve();
       expect(theorems[0].isSatisfiable()).to.be.true;
     });
     
-    it("invariant maintained by loop", async () => {
-      expect(theorems[1].description).to.be.eql("loop invariant:\ni <= 5");
+    it("invariant holds on entry", async () => {
+      expect(theorems[1].description).to.be.eql("loop entry:\ni <= 5");
       await theorems[1].solve();
       expect(theorems[1].isSatisfiable()).to.be.true;
     });
     
-    it("results in final state", async () => {
-      expect(theorems[2].description).to.be.eql("initially:\ni === 5");
+    it("invariant maintained by loop", async () => {
+      expect(theorems[2].description).to.be.eql("loop invariant:\ni <= 5");
       await theorems[2].solve();
       expect(theorems[2].isSatisfiable()).to.be.true;
     });

--- a/tests/verify.js
+++ b/tests/verify.js
@@ -114,34 +114,67 @@ describe("verify", () => {
       expect(theorems[1].isSatisfiable()).to.be.true;
     });
     
-    it("increment increments", async () => {
-      expect(theorems[2].description).to.be.eql("increment:\ncounter > old(counter)");
+    it("increment maintains invariants", async () => {
+      expect(theorems[2].description).to.be.eql("increment:\ntypeof counter == 'number'");
       await theorems[2].solve();
       expect(theorems[2].isSatisfiable()).to.be.true;
-    });
-        
-    it("increment maintains invariants", async () => {
-      expect(theorems[3].description).to.be.eql("increment:\ntypeof counter == 'number'");
+      expect(theorems[3].description).to.be.eql("increment:\ncounter >= 0");
       await theorems[3].solve();
       expect(theorems[3].isSatisfiable()).to.be.true;
-      expect(theorems[4].description).to.be.eql("increment:\ncounter >= 0");
+    });
+    
+    it("increment increments", async () => {
+      expect(theorems[4].description).to.be.eql("increment:\ncounter > old(counter)");
       await theorems[4].solve();
       expect(theorems[4].isSatisfiable()).to.be.true;
     });
-    
-    it("decrement decrements", async () => {
-      expect(theorems[5].description).to.be.eql("decrement:\nold(counter) > 0 ? counter < old(counter) : counter === old(counter)");
-      await theorems[5].solve();
-      expect(theorems[5].isSatisfiable()).to.be.true;
-    });
 
     it("decrement maintains invariants", async () => {
-      expect(theorems[6].description).to.be.eql("decrement:\ntypeof counter == 'number'");
+      expect(theorems[5].description).to.be.eql("decrement:\ntypeof counter == 'number'");
+      await theorems[5].solve();
+      expect(theorems[5].isSatisfiable()).to.be.true;
+      expect(theorems[6].description).to.be.eql("decrement:\ncounter >= 0");
       await theorems[6].solve();
       expect(theorems[6].isSatisfiable()).to.be.true;
-      expect(theorems[7].description).to.be.eql("decrement:\ncounter >= 0");
+    });
+    
+    it("decrement decrements", async () => {
+      expect(theorems[7].description).to.be.eql("decrement:\nold(counter) > 0 ? counter < old(counter) : counter === old(counter)");
       await theorems[7].solve();
       expect(theorems[7].isSatisfiable()).to.be.true;
+    });
+
+  });
+  
+  describe("simple steps", () => {
+    
+    const code = (() => {
+      let i = 0;
+      assert(i < 1);
+      i = 3;
+      assert(i < 2);
+    }).toString();
+    
+    let theorems;
+    
+    beforeEach(() => {
+      theorems = theoremsInSource(code.substring(14, code.length - 2));
+    });
+
+    it("finds all theorem", () => {
+      expect(theorems).to.have.length(2);
+    });
+    
+    it("verifies first assertion", async () => {
+      expect(theorems[0].description).to.be.eql("assert:\ni < 1");
+      await theorems[0].solve();
+      expect(theorems[0].isSatisfiable()).to.be.true;
+    });
+
+    it("does not verify second assertion", async () => {
+      expect(theorems[1].description).to.be.eql("assert:\ni < 2");
+      await theorems[1].solve();
+      expect(theorems[1].isSatisfiable()).to.be.false;
     });
     
   });

--- a/tests/verify.js
+++ b/tests/verify.js
@@ -221,4 +221,68 @@ describe("verify", () => {
     });
 
   });
+  
+  describe("sum", () => {
+    
+    const code = (() => {
+      function sumTo(n) {
+        requires(typeof n == "number");
+        requires(n >= 0);
+        
+        let i = 0, s = 0;
+      
+        while (i < n) {
+          invariant(i <= n);
+          invariant(s == (i + 1) * i / 2);
+          i++;
+          s = s + i;
+        }
+        
+        return s;
+        
+        ensures(sumTo(n) == (n + 1) * n / 2);
+      }
+    }).toString();
+    
+    let theorems;
+    
+    beforeEach(() => {
+      theorems = theoremsInSource(code.substring(14, code.length - 2));
+    });
+
+    it("finds all theorem", () => {
+      expect(theorems).to.have.length(5);
+    });
+    
+    it("verifies post condition", async () => {
+      expect(theorems[0].description).to.be.eql("sumTo:\nsumTo(n) == (n + 1) * n / 2");
+      await theorems[0].solve();
+      expect(theorems[0].isSatisfiable()).to.be.true;
+    });
+    
+    it("bound invariant holds on loop entry", async () => {
+      expect(theorems[1].description).to.be.eql("loop entry:\ni <= n");
+      await theorems[1].solve();
+      expect(theorems[1].isSatisfiable()).to.be.true;
+    });
+    
+    it("equality invariant holds on loop entry", async () => {
+      expect(theorems[2].description).to.be.eql("loop entry:\ns == (i + 1) * i / 2");
+      await theorems[2].solve();
+      expect(theorems[2].isSatisfiable()).to.be.true;
+    });
+    
+    it("counter invariant maintained by loop", async () => {
+      expect(theorems[3].description).to.be.eql("loop invariant:\ni <= n");
+      await theorems[3].solve();
+      expect(theorems[3].isSatisfiable()).to.be.true;
+    });
+
+    it("equality invariant maintained by loop", async () => {
+      expect(theorems[4].description).to.be.eql("loop invariant:\ns == (i + 1) * i / 2");
+      await theorems[4].solve();
+      expect(theorems[4].isSatisfiable()).to.be.true;
+    });
+
+  });
 });


### PR DESCRIPTION
This PR adds enables verification of `while` loops. This is done by proving that all loop invariants hold on entry and are maintained by the loop. Then, the surrounding scope of the loop will omit the loop body and safely assume that the loop invariant holds after the loop while the loop condition does not hold anymore.

This kind of verification for loops also enables simple induction proofs, e.g. the following program proves that the sum of the first `n` natural numbers is `(n+1) * n / 2`.

``` js
function sumTo(n) {
  requires(typeof n == "number");
  requires(n >= 0);

  let i = 0, s = 0;
  while (i < n) {
    invariant(i <= n);
    invariant(s == (i + 1) * i / 2);
    i++;
    s = s + i;
  }
  return s;

  ensures(sumTo(n) == (n + 1) * n / 2);
}
```
